### PR TITLE
Include subtitles in search results; #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,18 @@ if ( function_exists( 'get_the_subtitle' ) ) {
 
 An ID isn't necessary for `get_the_subtitle`, but will work for retrieving subtitles from posts that aren't currently being viewed.
 
+---
+
+### Searching Subtitles ###
+
+The plugin will filter search queries to also check the subtitle field in addition to the `post_title` and `post_content` fields, both in the Admin Dashboard and front-end search function. If you wish to disable this functionality, you can do so in your plugin or themes setup file:
+
+```php
+if ( class_exists( 'Subtitles' ) &&  method_exists( 'Subtitles', 'search_subtitles' ) ) {
+    remove_action( 'pre_get_posts', array( Subtitles::getInstance(), 'search_subtitles' ) );
+}
+```
+
 ## Changelog
 
 All versions of _Subtitles_ can be found on the [Releases](https://github.com/philiparthurmoore/Subtitles/releases) page.


### PR DESCRIPTION
Hello -- I stumbled upon your plugin and fit the need for our website perfectly. The code is well organized and makes good use of filters and hooks to allow the plugin behavior to be further adjusted. 

One thing we needed was the ability for the search function to also search the subtitle field (#37). 

I tried a lot of different ways to achieve this; this pull request is what I finally came up with that achieved the desired behavior.  However, I am not 100% certain that this implementation will not cause conflicts when other plugins or themes may attempt to further filter the search query, so it would be good if someone else can also look over this and do some testing to see if this implementation works safely. 

# My solution

The solution in this pull request uses the [posts_clauses](https://codex.wordpress.org/Plugin_API/Filter_Reference/posts_clauses) filter to directly modify the MySQL query clauses. 

It performs regex matching to find the search term and create an additional WHERE clause. 

### The pros are:

1. It keeps the query safe because WordPress has already sanitized the search term before placing it in the query clauses. 
2. It retains the default WordPress behavior for multiple search terms -- in other words, when the user searches for "foo bar" it will be broken into two separate terms, "foo" and "bar" and this method retains that specificity in the query. 
3. It works in the Admin Dashboard and front-end

### The cons are:

1. It directly modifies the MySQL clauses and *may* have unintended side-effects if other themes or plugins also attempt to filter the search queries. Further testing is required. 
2. It does not work if Meta Query parameters have been set by another plugin; in this case, the Meta Query works and the subtitle field is simply not searched. 

# Alternate method which did not work

I tried one other way to achieve this feature: Using the WP_Query Meta Query functionality would have been preferable because it would have made use of the built-in WP_Query object instead of modifying SQL directly.  For example:

```php
public function search_subtitles( $query ) {

	if ( $query->is_search ) {
		$args = array(
			array(
				'key'     => '_subtitle',
				'value'   => '%user_search_term%',
				'compare' => 'LIKE'
			),
		);
		$query->set( 'meta_query', $args );	
	}

	return $query;
}
```

This unfortunately does not work because in a search query, the results are still filtered down to only posts which have the `user_search_term` present in either the `post_title` or `post_content` fields. 

From searching online, others were able to implement this type of functionality by performing two queries and combining the results: 1) to search only the title and content fields, and 2) to search only the meta fields. 